### PR TITLE
Baseline correction

### DIFF
--- a/firmware/common/core/rtl/ClkSim.vhd
+++ b/firmware/common/core/rtl/ClkSim.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-10
--- Last update: 2018-09-28
+-- Last update: 2024-10-10
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -34,15 +34,18 @@ use unisim.vcomponents.all;
 entity ClkSim is
   generic ( VCO_HALF_PERIOD_G : time    := 4 ps;
             TIM_DIVISOR_G     : natural := 337;
-            PHY_DIVISOR_G     : natural := 50 );
+            PHY_DIVISOR_G     : natural := 50;
+            ADC_DIVISOR_G     : natural := 200 );
   port ( phyClk      : out sl;
-         evrClk      : out sl );
+         evrClk      : out sl;
+         adcClk      : out sl);
 end ClkSim;
 
 architecture behavior of ClkSim is
   signal vco : sl;
   signal iphyClk : sl := '0';
   signal ievrClk : sl := '0';
+  signal iadcClk : sl := '0';
 begin
 
   process is
@@ -54,12 +57,19 @@ begin
   end process;
 
   process (vco) is
+    variable iadcCnt : integer := 0;
+    variable iadcClk : sl := '0';
     variable ievrCnt : integer := 0;
     variable ievrClk : sl := '0';
     variable iphyCnt : integer := 0;
     variable iphyClk : sl := '0';
   begin
     if rising_edge(vco) then
+      iadcCnt := iadcCnt + 1;
+      if iadcCnt = ADC_DIVISOR_G then
+        iadcCnt := 0;
+        iadcClk := not iadcClk;
+      end if;
       ievrCnt := ievrCnt + 1;
       if ievrCnt = TIM_DIVISOR_G then
         ievrCnt := 0;
@@ -71,6 +81,7 @@ begin
         iphyClk := not iphyClk;
       end if;
     end if;
+    adcClk <= iadcClk;
     evrClk <= ievrClk;
     phyClk <= iphyClk;
   end process;

--- a/firmware/common/core/rtl/QuadAdcPkg.vhd
+++ b/firmware/common/core/rtl/QuadAdcPkg.vhd
@@ -121,7 +121,7 @@ package QuadAdcPkg is
   constant RAM_ADDR_WIDTH_C : integer := bitSize(RAM_DEPTH_C-1);
   constant CACHE_ADDR_LEN_C : integer := RAM_ADDR_WIDTH_C+IDX_BITS;
   constant SKIP_CHAR : slv(1 downto 0) := "10";
-  constant CACHETYPE_LEN_C : integer := 32 + 2*IDX_BITS+2*CACHE_ADDR_LEN_C;
+  constant CACHETYPE_LEN_C : integer := 33 + 2*IDX_BITS+2*CACHE_ADDR_LEN_C;
   
   type CacheStateType is ( EMPTY_S,  -- buffer empty
                            OPEN_S,   -- buffer filling
@@ -150,6 +150,7 @@ package QuadAdcPkg is
     valid  : sl;
     skip   : sl;
     ovflow : sl;
+    oor    : sl;
   end record;
   constant CACHE_INIT_C : CacheType := (
     state  => EMPTY_S,
@@ -164,7 +165,8 @@ package QuadAdcPkg is
     didxs  => 0,
     valid  => '0',
     skip   => '0',
-    ovflow => '0' );
+    ovflow => '0',
+    oor    => '0');
   
   type CacheArray is array(natural range<>) of CacheType;
   type CacheStatusArray is array(natural range<>) of CacheArray(MAX_OVL_C-1 downto 0);
@@ -409,6 +411,7 @@ package body QuadAdcPkg is
     assignSlv(i, vector, status.valid);
     assignSlv(i, vector, status.skip);
     assignSlv(i, vector, status.ovflow);
+    assignSlv(i, vector, status.oor);
     return vector;
   end function;
   
@@ -442,6 +445,7 @@ package body QuadAdcPkg is
     assignRecord(i, vector, status.valid);
     assignRecord(i, vector, status.skip);
     assignRecord(i, vector, status.ovflow);
+    assignRecord(i, vector, status.oor);
     return status;
   end function;
 

--- a/firmware/common/fex/rtl/hsd_baseline_corr.vhd
+++ b/firmware/common/fex/rtl/hsd_baseline_corr.vhd
@@ -1,0 +1,164 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+use IEEE.std_logic_unsigned.all;
+use IEEE.numeric_std.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use work.FmcPkg.all;
+
+entity hsd_baseline_corr is
+  generic (
+    TPD_G      : time := 1 ns;
+    NUMWORDS_G : integer := 40;
+    MAXACCUM_G : integer := 12 );
+  port (
+    rst       : in  std_logic;
+    clk       : in  std_logic;
+    accShift  : in  slv( 3 downto 0) := toSlv(12,4); -- 3 <= accShift <= 12
+    baseline  : in  slv(14 downto 0) := toSlv(2**14,15);
+    tIn       : in  Slv2Array   (NUMWORDS_G/4-1 downto 0);
+    adcIn     : in  AdcWordArray(NUMWORDS_G-1 downto 0);
+    tOut      : out Slv2Array   (NUMWORDS_G/4-1 downto 0);
+    adcOut    : out Slv15Array  (NUMWORDS_G-1 downto 0) );
+end;  
+
+architecture behav of hsd_baseline_corr is
+
+  constant MAXACCUM_C : integer := MAXACCUM_G;
+  
+  type StateType is (IDLE_S, ACCUM_S);
+  
+  type RegType is record
+    tOut    : Slv2Array (NUMWORDS_G/4-1 downto 0);
+    adcOut  : Slv15Array(NUMWORDS_G-1 downto 0);
+    adcSum  : Slv15Array(3 downto 0);
+    adcRun  : Slv24Array(3 downto 0);
+    adcCorr : Slv15Array(3 downto 0);
+    addr    : slv(MAXACCUM_C-4 downto 0);
+    wraddr  : slv(MAXACCUM_C-4 downto 0);
+    rdaddr  : slv(MAXACCUM_C-4 downto 0);
+  end record;
+
+  constant REG_INIT_C : RegType := (
+    tOut    => (others=>"00"),
+    adcOut  => (others=>toSlv(0,15)),
+    adcSum  => (others=>toSlv(0,15)),
+    adcRun  => (others=>toSlv(0,24)),
+    adcCorr => (others=>toSlv(2**14,15)),
+    addr    => toSlv(0,MAXACCUM_C-3),
+    wraddr  => toSlv(0,MAXACCUM_C-3),
+    rdaddr  => toSlv(1,MAXACCUM_C-3) );
+
+  signal r    : RegType := REG_INIT_C;
+  signal r_in : RegType;
+    
+  --  Running sum signals
+  signal din  : slv(59 downto 0);
+  signal dout : slv(59 downto 0);
+  signal adcSumO : Slv15Array(3 downto 0);
+  
+begin
+
+  tOut   <= r.tOut;
+  adcOut <= r.adcOut;
+
+  U_RAM : entity surf.SimpleDualPortRam
+    generic map (
+      DATA_WIDTH_G => 4*(12+3),
+      ADDR_WIDTH_G => MAXACCUM_C-3 )
+    port map (
+      clka     => clk,
+      wea      => '1',
+      addra    => r.wraddr,
+      dina     => din,
+      clkb     => clk,
+      rstb     => rst,
+      addrb    => r.rdaddr,
+      doutb    => dout );
+
+  din        <= r.adcSum(3) & r.adcSum(2) & r.adcSum(1) & r.adcSum(0);
+  adcSumO(0) <= dout(14 downto 0);
+  adcSumO(1) <= dout(29 downto 15);
+  adcSumO(2) <= dout(44 downto 30);
+  adcSumO(3) <= dout(59 downto 45);
+
+  comb : process ( rst, r, adcIn, tIn, adcSumO, accShift, baseline ) is
+    variable v : RegType;
+    variable k : integer;
+    variable n : integer;
+    variable q : slv(15 downto 0);
+    variable start : sl;
+    constant OUT_OF_RANGE : slv(14 downto 0) := (others=>'1');
+  begin
+    v := r;
+
+    v.tOut := tIn;
+    
+    start := '0';
+    for j in 0 to 9 loop
+      if tIn(j)(0)='1' then
+        start := '1';
+      end if;
+    end loop;
+    
+    if start = '1' then
+      for i in 0 to 3 loop
+        v.adcCorr(i) := r.adcRun(i)(14+n downto n);
+      end loop;
+    end if;
+    
+    k := 0;
+    for j in 0 to 9 loop
+      for i in 0 to 3 loop
+        q := (others=>'0');
+        q(14 downto 3) := adcIn(k)(11 downto 0); -- f(11:3)
+        q := q + resize(baseline,16) - resize(v.adcCorr(i),16);
+        if q(15) = '1' then -- underflow/overflow
+          v.adcOut(k) := OUT_OF_RANGE;
+        else
+          v.adcOut(k) := resize(q,15);
+        end if;
+        k := k+1;
+      end loop;
+    end loop;
+
+    k := 0;
+    v.adcSum := (others=>toSlv(0,15));
+    --for j in 0 to 9 loop  -- 10 does not give us powers of 2!
+    --  Another possibility is to sum all 10 and keep a factor of 10 in the output
+    for j in 0 to 7 loop
+      for i in 0 to 3 loop
+        v.adcSum(i) := v.adcSum(i) + adcIn(k);
+        k           := k+1;
+      end loop;
+    end loop;
+
+    for i in 0 to 3 loop
+      v.adcRun(i) := r.adcRun(i) + r.adcSum(i) - adcSumO(i);
+    end loop;
+
+    v.addr   := r.addr+1;
+    n := conv_integer(accShift)-3;
+    v.wraddr := resize(r.addr(n-1 downto 0),MAXACCUM_C-3);
+    v.rdaddr := resize(v.addr(n-1 downto 0),MAXACCUM_C-3);
+    -- if r.rdaddr(n-1 downto 0) = toSlv(-1,n) then
+    --   v.rdaddr := (others=>'0');
+    -- end if;
+    
+    if rst = '1' then
+      v := REG_INIT_C;
+    end if;
+
+    r_in <= v;
+  end process comb;
+
+  seq : process ( clk ) is
+  begin
+    if rising_edge(clk) then
+      r <= r_in after TPD_G;
+    end if;
+  end process seq;
+
+end behav;

--- a/firmware/common/fex/rtl/hsd_baseline_corr.vhd
+++ b/firmware/common/fex/rtl/hsd_baseline_corr.vhd
@@ -128,7 +128,7 @@ begin
     end loop;
 
     v.adcOut := r.adcNew;
-    v.tOut   := t.tNew;
+    v.tOut   := r.tNew;
     k := 0;
     for j in 0 to 9 loop
       for i in 0 to 3 loop

--- a/firmware/common/fex/rtl/hsd_thr_ilv_native_fine.vhd
+++ b/firmware/common/fex/rtl/hsd_thr_ilv_native_fine.vhd
@@ -13,7 +13,8 @@ use work.QuadAdcPkg.all;
 entity hsd_thr_ilv_native_fine is
 generic (
     ILV_G                    : INTEGER := 4;
-    BASELINE                 : AdcWord);
+    BASECORR                 : boolean := true;
+    BASELINE                 : slv(14 downto 0) := toSlv(2**14,15) );
 port (
     ap_clk   : IN STD_LOGIC;
     ap_rst_n : IN STD_LOGIC;
@@ -50,10 +51,11 @@ architecture behav of hsd_thr_ilv_native_fine is
   constant KEEP_ROWS_C : integer := 3;
   constant CBITS_C : integer := bitSize(KEEP_ROWS_C*ROW_SIZE);
   constant ADDRB_C : integer := bitSize(2*KEEP_ROWS_C+3);
-
+  constant MAXACCUM_C : integer := 12;
+  
   type RegType is record
-    xlo        : AdcWord;           -- low threshold
-    xhi        : AdcWord;           -- high threshold
+    xlo        : slv(14 downto 0);           -- low threshold
+    xhi        : slv(14 downto 0);           -- high threshold
     tpre       : slv(CBITS_C-1 downto 0);  -- number of super samples to readout before crossing
     tpost      : slv(CBITS_C-1 downto 0);  -- number of super samples to readout after crossing
     tpreRows   : integer range 0 to KEEP_ROWS_C;
@@ -83,8 +85,11 @@ architecture behav of hsd_thr_ilv_native_fine is
     y          : Slv16Array(ILV_G*ROW_SIZE+ILV_G-1 downto 0); -- readout
     t          : Slv2Array (      ROW_SIZE downto 0);
     yv         : slv       (      ROW_IDXB-1 downto 0);  -- number of valid
-                                                         -- readout samples
-    
+    --  baseline correction configuration
+    baseline   : slv(14 downto 0);
+    acc_shift  : slv( 3 downto 0);
+    acc_rst    : sl;
+    --
     readSlave  : AxiLiteReadSlaveType;
     writeSlave : AxiLiteWriteSlaveType;
   end record;
@@ -120,14 +125,24 @@ architecture behav of hsd_thr_ilv_native_fine is
     y          => (others=>(others=>'0')),
     t          => (others=>(others=>'0')),
     yv         => (others=>'0'),
+    --  baseline correction configuration
+    baseline   => BASELINE,
+    acc_shift  => toSlv(12,4),
+    acc_rst    => '1',
+    --
     readSlave  => AXI_LITE_READ_SLAVE_INIT_C,
     writeSlave => AXI_LITE_WRITE_SLAVE_INIT_C );
 
   signal r    : RegType := REG_INIT_C;
   signal r_in : RegType;
 
-  signal xsave : AdcWordArray(ILV_G*ROW_SIZE-1 downto 0);
-  signal tsave : Slv2Array   (      ROW_SIZE-1 downto 0);
+  --constant ADCWLEN_C : integer := AdcWord'length;
+  constant ADCWLEN_C : integer := 15;
+  signal xC : Slv15Array(ILV_G*ROW_SIZE-1 downto 0);
+  signal tC : Slv2Array (ROW_SIZE-1 downto 0);
+
+  signal xsave : Slv15Array(ILV_G*ROW_SIZE-1 downto 0);
+  signal tsave : Slv2Array (      ROW_SIZE-1 downto 0);
 
   constant ANY_SKIP_G : boolean := true;
   
@@ -136,6 +151,26 @@ begin
   axilWriteSlave <= r.writeSlave;
   axilReadSlave  <= r.readSlave;
 
+  GEN_CORR : if BASECORR generate
+    U_CORR : entity work.hsd_baseline_corr
+      port map (
+        rst      => r.acc_rst,
+        clk      => ap_clk,
+        accShift => r.acc_shift,
+        baseline => r.baseline,
+        tIn      => tin,
+        adcIn    => x,
+        tOut     => tC,
+        adcOut   => xC);
+  end generate GEN_CORR;
+
+  NO_GEN_CORR : if not BASECORR generate
+    tC <= tIn;
+    GEN_XC : for i in xC'range generate
+      xC(i) <= resize(x(i),15);
+    end generate GEN_XC;
+  end generate NO_GEN_CORR;
+  
   --
   --  Buffer of sample and trigger data
   --    Necessary for prepending samples when a threshold crossing
@@ -143,17 +178,17 @@ begin
   --
   GEN_RAM : for i in 0 to ROW_SIZE-1 generate
     U_RAMB : block is
-      signal din,dout : slv(ILV_G*AdcWord'length+1 downto 0);
+      signal din,dout : slv(ILV_G*ADCWLEN_C+1 downto 0);
     begin
       GEN_DIN : for j in 0 to ILV_G-1 generate
-        din((j+1)*AdcWord'length-1 downto j*AdcWord'length) <= x(i*ILV_G+j);
-        xsave(i*ILV_G+j) <= dout((j+1)*AdcWord'length-1 downto j*AdcWord'length);
+        din((j+1)*ADCWLEN_C-1 downto j*ADCWLEN_C) <= xC(i*ILV_G+j);
+        xsave(i*ILV_G+j) <= dout((j+1)*ADCWLEN_C-1 downto j*ADCWLEN_C);
       end generate;
-      din(ILV_G*AdcWord'length+1 downto ILV_G*AdcWord'length) <= tin(i);
-      tsave(i) <= dout(ILV_G*AdcWord'length+1 downto ILV_G*AdcWord'length);
+      din(ILV_G*ADCWLEN_C+1 downto ILV_G*ADCWLEN_C) <= tC(i);
+      tsave(i) <= dout(ILV_G*ADCWLEN_C+1 downto ILV_G*ADCWLEN_C);
       
       U_RAM : entity surf.SimpleDualPortRam
-        generic map ( DATA_WIDTH_G => ILV_G*AdcWord'length+2,
+        generic map ( DATA_WIDTH_G => ILV_G*ADCWLEN_C+2,
                       ADDR_WIDTH_G => r.waddr'length )
         port map ( clka                => ap_clk,
                    wea                 => '1',
@@ -165,7 +200,7 @@ begin
     end block;
   end generate;
   
-  comb : process ( ap_rst_n, r, x, tin, xsave, tsave,
+  comb : process ( ap_rst_n, r, xC, tC, xsave, tsave,
                    axilWriteMaster, axilReadMaster ) is
     variable v      : RegType;
     variable ep     : AxiLiteEndPointType;
@@ -194,7 +229,13 @@ begin
                                                  -- crossing
     axiSlaveRegister ( ep, x"28", 0, v.tpost );  -- samples after gate
                                                  -- closes/thr crossing
-
+    axiSlaveRegister ( ep, x"40", 0, v.baseline );
+    axiSlaveRegister ( ep, x"44", 0, v.acc_shift );
+    axiWrDetect( ep, x"44", v.acc_rst);
+    if v.acc_shift < toSlv(3,4) or v.acc_shift > toSlv(MAXACCUM_C,4) then
+      v.acc_shift := r.acc_shift;
+    end if;
+    
     tpre  := conv_integer(r.tpre);
     tpost := conv_integer(r.tpost);
     v.tpreRows  := (tpre +ROW_SIZE-1)/ROW_SIZE;
@@ -221,7 +262,7 @@ begin
     for i in 0 to ROW_SIZE-1 loop
       for j in 0 to ILV_G-1 loop
         k := 4*i+j;
-        if ((x(k) < r.xlo) or (x(k) > r.xhi) or (tin(i) /= "00")) then
+        if ((xC(k) < r.xlo) or (xC(k) > r.xhi) or (tC(i) /= "00")) then
           ikeepl := i;
         end if;
       end loop;
@@ -232,7 +273,7 @@ begin
     for i in ROW_SIZE-1 downto 0 loop
       for j in 0 to ILV_G-1 loop
         k := 4*i+j;
-        if ((x(k) < r.xlo) or (x(k) > r.xhi) or (tin(i) /= "00")) then
+        if ((xC(k) < r.xlo) or (xC(k) > r.xhi) or (tC(i) /= "00")) then
           ikeepf := i;
         end if;
       end loop;

--- a/firmware/common/fex/rtl/hsd_thr_ilv_native_fine.vhd
+++ b/firmware/common/fex/rtl/hsd_thr_ilv_native_fine.vhd
@@ -231,6 +231,7 @@ begin
                                                  -- closes/thr crossing
     axiSlaveRegister ( ep, x"40", 0, v.baseline );
     axiSlaveRegister ( ep, x"44", 0, v.acc_shift );
+    v.acc_rst := '0';
     axiWrDetect( ep, x"44", v.acc_rst);
     if v.acc_shift < toSlv(3,4) or v.acc_shift > toSlv(MAXACCUM_C,4) then
       v.acc_shift := r.acc_shift;

--- a/firmware/common/sim/rtl/AdcDataFromFile.vhd
+++ b/firmware/common/sim/rtl/AdcDataFromFile.vhd
@@ -1,0 +1,117 @@
+-------------------------------------------------------------------------------
+-- Title      : 
+-------------------------------------------------------------------------------
+-- File       : AdcDataFromFile.vhd
+-- Author     : Matt Weaver <weaver@slac.stanford.edu>
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2015-07-10
+-- Last update: 2024-09-30
+-- Platform   : 
+-- Standard   : VHDL'93/02
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- This file is part of 'LCLS2 DAQ Software'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'LCLS2 DAQ Software', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use IEEE.NUMERIC_STD.all;
+use ieee.std_logic_unsigned.all;
+
+use STD.textio.all;
+use ieee.std_logic_textio.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+library work;
+use work.FmcPkg.all;
+
+entity AdcDataFromFile is
+  generic ( FILENAME_G : string := "default.xtc";
+            NUMWORDS_G : integer := 40 );
+  port ( rst         : in  sl;
+         clk         : in  sl;
+         adcWords    : out AdcWordArray(NUMWORDS_G-1 downto 0);
+         start       : out sl );
+end AdcDataFromFile;
+
+architecture behavior of AdcDataFromFile is
+
+  signal str : string(1 to 4*NUMWORDS_G+2);
+  
+begin
+
+  process is
+    function Slv4FromChar(v : in character) return slv is
+      variable result : slv(3 downto 0) := x"0";
+    begin
+      case(v) is
+        when '0' => result := x"0";
+        when '1' => result := x"1";
+        when '2' => result := x"2";
+        when '3' => result := x"3";
+        when '4' => result := x"4";
+        when '5' => result := x"5";
+        when '6' => result := x"6";
+        when '7' => result := x"7";
+        when '8' => result := x"8";
+        when '9' => result := x"9";
+        when 'a' => result := x"a";
+        when 'b' => result := x"b";
+        when 'c' => result := x"c";
+        when 'd' => result := x"d";
+        when 'e' => result := x"e";
+        when 'f' => result := x"f";
+        when others => null;
+      end case;
+      return result;
+    end function;
+
+    function ArrayFromString(v : string) return AdcWordArray is
+      variable result : AdcWordArray(NUMWORDS_G-1 downto 0);
+      variable k : integer;
+    begin
+      k := 1;
+      for i in 0 to NUMWORDS_G-1 loop
+        k := k+1; -- skip over space
+        for j in 2 downto 0 loop
+          result(i)(j*4+3 downto j*4) := Slv4FromChar(v(k));
+          k := k+1;
+        end loop;
+      end loop;
+      return result;
+    end function;
+
+    file results : text;
+    variable iline : line;
+    variable istr : string(str'range);
+  begin
+    file_open(results, FILENAME_G, read_mode);
+    while not endfile(results) loop
+      wait until falling_edge(clk);
+      readline(results, iline);
+      read(iline, istr);        
+      adcWords  <= ArrayFromString(istr(1 to 4*NUMWORDS_G));
+      str       <= istr;
+      if istr(istr'right)='0' then
+        start <= '0';
+      else
+        start <= '1';
+      end if;
+      
+      if rst = '1' then
+        adcWords  <= (others=>x"800");
+        start     <= '0';
+      end if;
+    end loop;
+    file_close(results);
+  end process;
+
+end behavior;

--- a/firmware/common/sim/rtl/AdcDataToFile.vhd
+++ b/firmware/common/sim/rtl/AdcDataToFile.vhd
@@ -1,0 +1,111 @@
+-------------------------------------------------------------------------------
+-- Title      : 
+-------------------------------------------------------------------------------
+-- File       : AdcDataToFile.vhd
+-- Author     : Matt Weaver <weaver@slac.stanford.edu>
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2015-07-10
+-- Last update: 2024-09-30
+-- Platform   : 
+-- Standard   : VHDL'93/02
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- This file is part of 'LCLS2 DAQ Software'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'LCLS2 DAQ Software', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use IEEE.NUMERIC_STD.all;
+use ieee.std_logic_unsigned.all;
+
+use STD.textio.all;
+use ieee.std_logic_textio.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+library work;
+use work.FmcPkg.all;
+
+entity AdcDataToFile is
+  generic ( FILENAME_G : string := "default.xtc";
+            NUMWORDS_G : integer := 40 );
+  port ( rst         : in  sl;
+         clk         : in  sl;
+         adcWords    : in  Slv15Array(NUMWORDS_G-1 downto 0);
+         start       : in  sl );
+end AdcDataToFile;      
+
+architecture behavior of AdcDataToFile is
+
+begin
+
+  process is
+
+    function HexChar(v : in slv(3 downto 0)) return character is
+      variable result : character := '0';
+    begin
+      case(v) is
+        when x"0" => result := '0';
+        when x"1" => result := '1';
+        when x"2" => result := '2';
+        when x"3" => result := '3';
+        when x"4" => result := '4';
+        when x"5" => result := '5';
+        when x"6" => result := '6';
+        when x"7" => result := '7';
+        when x"8" => result := '8';
+        when x"9" => result := '9';
+        when x"A" => result := 'a';
+        when x"B" => result := 'b';
+        when x"C" => result := 'c';
+        when x"D" => result := 'd';
+        when x"E" => result := 'e';
+        when x"F" => result := 'f';
+        when others => null;
+      end case;
+      return result;
+    end function;
+
+    function HexString(v : in slv(15 downto 0)) return string is
+      variable result : string(4 downto 1);
+    begin
+      for i in 0 to 3 loop
+        result(i+1) := HexChar(v(4*i+3 downto 4*i));
+      end loop;
+      return result;
+    end function;
+
+    file results : text;
+    variable oline : line;
+    constant startOn  : string(1 to 1) := (others=>'1');
+    constant startOff : string(1 to 1) := (others=>'0');
+    
+  begin
+    file_open(results, FILENAME_G, write_mode);
+    loop
+      wait until rising_edge(clk);
+      for i in 0 to NUMWORDS_G-1 loop
+        write(oline, HexString(resize(adcWords(i),16)), right, 5);
+      end loop;
+
+      if start = '1' then
+        write(oline, startOn, right, 2);
+      else
+        write(oline, startOff, right, 2);
+      end if;
+      
+      if rst = '0' then
+        writeline(results, oline);
+      end if;
+    end loop;
+    file_close(results);
+  end process;
+
+end behavior;

--- a/firmware/common/v3/rtl/AdcRamp.vhd
+++ b/firmware/common/v3/rtl/AdcRamp.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-10
--- Last update: 2019-12-06
+-- Last update: 2024-10-10
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -44,6 +44,7 @@ entity AdcRamp is
          dmaClk      : out sl;
          ready       : in  sl;
          adcOut      : out AdcDataArray(3 downto 0);
+         serOut      : out AdcWord;
          trigSel     : in  sl;
          trigOut     : out slv(ROW_SIZE-1 downto 0)
     );
@@ -54,7 +55,7 @@ architecture behavior of AdcRamp is
   signal adcI,adcO        : AdcDataArray (3 downto 0);
 
   signal trigIn  : slv(ROW_SIZE-1 downto 0) := (others=>'0');
-   
+  
 begin
 
   dmaClk  <= adcClk;
@@ -80,15 +81,19 @@ begin
      variable s : slv(15 downto 0) := (others=>'0');
      variable d : slv( 2 downto 0) := (others=>'0');
      variable t : integer          := 0;
+     variable ch : integer := 0;
    begin
      if rst = '1' then
        s := x"0c00";
        d := (others=>'0');
        t := 0;
      elsif rising_edge(phyClk) then
-       for ch in 0 to 3 loop
-         adcI(ch).data <= resize(s,AdcWord'length) & adcI(ch).data(ROW_SIZE-1 downto 1);
-       end loop;
+       serOut <= s;
+       ch := ch+1;
+       if ch=4 then
+         ch := 0;
+       end if;
+       adcI(ch).data <= resize(s,AdcWord'length) & adcI(ch).data(ROW_SIZE-1 downto 1);
        
        trigIn <= d(0) & trigIn(ROW_SIZE-1 downto 1);
        d := trigSel & d(2 downto 1);

--- a/firmware/common/v3/rtl/hsd_fex_packed.vhd
+++ b/firmware/common/v3/rtl/hsd_fex_packed.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2016-01-04
--- Last update: 2024-04-24
+-- Last update: 2024-09-30
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -706,7 +706,10 @@ begin
   GEN_NAF : if ALGORITHM_G = "NAF" generate
     U_FEX : entity work.hsd_thr_ilv_native_fine
       generic map ( ILV_G => ILV_G,
-                    BASELINE => ("01" & toSlv(0,AdcWord'length-2)) )
+                    -- BASECORR => false,
+                    -- BASELINE => toSlv(2**11,15) )
+                    BASECORR => true,
+                    BASELINE => toSlv(2**14,15) )
       port map ( ap_clk          => clk,
                  ap_rst_n        => rstn,
                  sync            => configSync,

--- a/firmware/targets/hsd_6400m_sim/hdl/hsd_6400m_sim.vhd
+++ b/firmware/targets/hsd_6400m_sim/hdl/hsd_6400m_sim.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-10
--- Last update: 2024-04-29
+-- Last update: 2024-10-09
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -154,7 +154,7 @@ architecture top_level_app of hsd_6400m_sim is
    signal fmcClk  : slv(NFMC_C-1 downto 0);
    signal msgConfig    : XpmPartMsgConfigType := XPM_PART_MSG_CONFIG_INIT_C;
 
-   constant CMDS_C : AxiLiteWriteCmdArray(0 to 25) := (
+   constant CMDS_C : AxiLiteWriteCmdArray(0 to 27) := (
      --  Chip Adc Reg
      ( addr => x"00000010", value => x"000000ff" ), -- assert DMA rst
      ( addr => x"00000010", value => x"00000000" ), -- release DMA rst
@@ -166,16 +166,18 @@ architecture top_level_app of hsd_6400m_sim is
      ( addr => x"00001014", value => x"00000064" ), -- fexLen/prescale
      ( addr => x"00001018", value => x"00040C00" ), -- almostFull
      ( addr => x"00001020", value => x"00000004" ), -- fexBegin
-     ( addr => x"00001024", value => x"00100064" ), -- fexLen/prescale
+     ( addr => x"00001024", value => x"00000064" ), -- fexLen/prescale
      ( addr => x"00001028", value => x"00040C00" ), -- almostFull
      ( addr => x"00001030", value => x"00000004" ), -- fexBegin
      ( addr => x"00001034", value => x"00200064" ), -- fexLen/prescale
      ( addr => x"00001038", value => x"00040C00" ), -- almostFull
-     ( addr => x"00001210", value => x"00000801" ), -- prescale
-     ( addr => x"00001218", value => x"0000080E" ), -- fexLen/delay
-     ( addr => x"00001220", value => x"00000001" ), -- almostFull
-     ( addr => x"00001228", value => x"00000002" ), -- prescale
-     ( addr => x"00001000", value => x"00010000" ), -- fexEnable
+     ( addr => x"00001210", value => x"00000801" ), -- xlo
+     ( addr => x"00001218", value => x"0000080E" ), -- xhi
+     ( addr => x"00001220", value => x"00000001" ), -- tpre
+     ( addr => x"00001228", value => x"00000002" ), -- tpost
+     ( addr => x"00001240", value => x"00004000" ), -- baseline
+     ( addr => x"00001244", value => x"0000000c" ), -- acc_shift
+     ( addr => x"00001000", value => x"00000003" ), -- fexEnable
      -- Chip Adc Reg
      ( addr => x"00000010", value => x"C0000000" ), -- enable
      -- XpmMessageAligner

--- a/firmware/targets/hsd_6400m_sim/hdl/hsd_6400m_sim.vhd
+++ b/firmware/targets/hsd_6400m_sim/hdl/hsd_6400m_sim.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-10
--- Last update: 2024-10-09
+-- Last update: 2024-10-10
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -58,7 +58,8 @@ architecture top_level_app of hsd_6400m_sim is
 
    constant NCHAN_C : integer := 2;
    constant NFMC_C  : integer := 2;
-
+   constant NUMWORDS_C : integer := 4*ROW_SIZE;
+   
    signal rst      : sl;
    
     -- AXI-Lite and IRQ Interface
@@ -91,10 +92,7 @@ architecture top_level_app of hsd_6400m_sim is
    signal phyClk            : sl;
    signal refTimingClk      : sl;
    signal refTimingRst      : sl;
-   signal adcO              : AdcDataArray(3 downto 0);
    signal adcI              : AdcDataArray(4*NFMC_C-1 downto 0);
-   signal trigIn            : slv(ROW_SIZE-1 downto 0);
-   signal trigSel           : slv(1 downto 0);
    signal trigSlot          : slv(1 downto 0);
    
 --   constant AXIS_CONFIG_C : AxiStreamConfigType := ssiAxiStreamConfig(16);
@@ -176,7 +174,7 @@ architecture top_level_app of hsd_6400m_sim is
      ( addr => x"00001220", value => x"00000001" ), -- tpre
      ( addr => x"00001228", value => x"00000002" ), -- tpost
      ( addr => x"00001240", value => x"00004000" ), -- baseline
-     ( addr => x"00001244", value => x"0000000c" ), -- acc_shift
+     ( addr => x"00001244", value => x"00000006" ), -- acc_shift
      ( addr => x"00001000", value => x"00000003" ), -- fexEnable
      -- Chip Adc Reg
      ( addr => x"00000010", value => x"C0000000" ), -- enable
@@ -196,6 +194,11 @@ architecture top_level_app of hsd_6400m_sim is
    signal xpmConfig    : XpmConfigType := XPM_CONFIG_INIT_C;
    signal xpmStream    : XpmStreamType := XPM_STREAM_INIT_C;
    signal timingStream : XpmStreamType := XPM_STREAM_INIT_C;
+
+   signal adcIn  : AdcWordArray(NUMWORDS_C-1 downto 0);
+   signal adcOut : Slv15Array  (NUMWORDS_C-1 downto 0);
+   signal adcSerialIn  : AdcWord;
+   signal adcSerialOut : slv(15 downto 0);
 
    type RegType is record
      advance : sl;
@@ -223,7 +226,7 @@ begin
     --  Need the full Xpm simulation for L0Raw
     xpmConfig.partition(0).master <= '1';
     xpmConfig.partition(0).l0Select.enabled <= '0';
-    xpmConfig.partition(0).l0Select.rateSel <= x"0000";
+    xpmConfig.partition(0).l0Select.rateSel <= x"0002";
     xpmConfig.partition(0).l0Select.destSel <= x"8000";
     xpmConfig.partition(0).l0Select.groups <= x"01";
     xpmConfig.partition(0).l0Select.rawPeriod <= x"0000A";
@@ -253,25 +256,25 @@ begin
    U_ClkSim : entity work.ClkSim
      generic map ( VCO_HALF_PERIOD_G => 21.0 ps,
                    TIM_DIVISOR_G     => 64,
-                   PHY_DIVISOR_G     => 2 )
+                   PHY_DIVISOR_G     => 2,
+                   ADC_DIVISOR_G     => 80 )
      port map ( phyClk   => phyClk,
-                evrClk   => refTimingClk );
+                evrClk   => refTimingClk,
+                adcClk   => dmaClk );
 
-   U_QIN : entity work.AdcRamp
-     generic map ( DATA_LO_G => x"0000",
-                   DATA_HI_G => x"0200" )
-     port map ( rst      => rst,
-                phyClk   => phyClk,
-                dmaClk   => dmaClk,
-                ready    => axilDone,
-                adcOut   => adcO,
-                trigSel  => trigSel(0),
-                trigOut  => trigIn );
+  -- read the raw data from a file
+  U_ADC_In : entity work.AdcDataFromFile
+    generic map ( FILENAME_G => "adcin.dat",
+                  NUMWORDS_G => NUMWORDS_C )
+    port map ( rst      => rst,
+               clk      => dmaClk,
+               adcWords => adcIn,
+               start    => open );
 
    GEN_ADC : for i in 0 to 3 generate
      GEN_ROW : for j in 0 to ROW_SIZE-1 generate
-       adcI(i+0).data(j) <= x"80" & adcO(i).data(j)(3 downto 0);
-       adcI(i+4).data(j) <= x"80" & adcO(i).data(j)(3 downto 0);
+       adcI(i+0).data(j) <= adcIn(j*4+i);
+       adcI(i+4).data(j) <= adcIn(j*4+i);
      end generate;
    end generate;
    
@@ -486,4 +489,30 @@ begin
     end if;
   end process;
 
+  --  this is just for display
+  adc64g_p : process (phyClk) is
+    variable adcDataIn  : AdcWordArray(NUMWORDS_C-1 downto 0) := (others=>x"000");
+    variable adcDataOut : Slv15Array(NUMWORDS_C-1 downto 0) := (others=>toSlv(0,15));
+    variable index : integer := NUMWORDS_C-1;
+  begin
+    if rising_edge(phyClk) then
+      if rst = '1' then
+        adcSerialIn  <= x"000";
+        adcSerialOut <= x"0000";
+        index        := NUMWORDS_C-1;
+        adcDataIn    := (others=>x"000");
+        adcDataOut   := (others=>toSlv(0,15));
+      else
+        if index = NUMWORDS_C-1 then
+          index      := 0;
+          adcDataIn  := adcIn;
+          adcDataOut := adcOut;
+        end if;
+        adcSerialIn  <= adcDataIn (index);
+        adcSerialOut <= resize(adcDataOut(index),16);
+        index := index + 1;
+      end if;
+    end if;
+  end process adc64g_p;
+  
 end top_level_app;

--- a/firmware/targets/hsd_fex_corr_sim/Makefile
+++ b/firmware/targets/hsd_fex_corr_sim/Makefile
@@ -1,0 +1,22 @@
+export GIT_BYPASS = 1
+
+# Define target output
+target: gui
+
+# Define Firmware Version Number
+export PRJ_VERSION = 00000000
+
+export REMOVE_UNUSED_CODE = 1
+export TIMING_EXT_PKG = 1
+
+# Define target part
+export PRJ_PART = XCKU085-FLVB1760-2-E
+export BOARD_PART =
+export PRJ_FMC = 134
+
+# Using a non-standard target directory structure, 
+# which requires me to define the TOP_DIR path
+export TOP_DIR = $(abspath $(PWD)/../..)
+
+# Use top level makefile
+include $(TOP_DIR)/submodules/ruckus/system_vivado.mk

--- a/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr.vhd
+++ b/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr.vhd
@@ -1,0 +1,68 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.std_logic_arith.all;
+use IEEE.std_logic_unsigned.all;
+use IEEE.numeric_std.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+use work.FmcPkg.all;
+
+entity hsd_fex_corr is
+generic (
+  NUMWORDS_G : integer := 40;
+  NUMACCUM_G : integer range 3 to 12 := 12;  -- 2s exponent of samples in baseline sums
+  BASELINE_G : slv(14 downto 0) := toSlv(2**14,15) );
+port (
+  rst       : in  std_logic;
+  clk       : in  std_logic;
+  start     : in  std_logic; -- accum baseline correction
+  adcIn     : in  AdcWordArray(NUMWORDS_G-1 downto 0);
+  adcOut    : out Slv15Array(NUMWORDS_G-1 downto 0) );
+end;  
+
+architecture behav of hsd_fex_corr is
+
+  type RegType is record
+    adcOut  : Slv15Array(NUMWORDS_G-1 downto 0);
+  end record;
+
+  constant REG_INIT_C : RegType := (
+    adcOut  => (others=>BASELINE_G) );
+
+  signal r    : RegType := REG_INIT_C;
+  signal r_in : RegType;
+
+begin
+  
+  adcOut <= r.adcOut;
+
+  comb : process ( rst, r, adcIn ) is
+    variable v : RegType;
+    variable k : integer;
+  begin
+    v := r;
+
+    k := 0;
+    for i in 0 to 9 loop
+      for j in 0 to 3 loop
+        v.adcOut(k) := adcIn(k) & "000";
+        k := k + 1;
+      end loop;
+    end loop;
+    
+    if rst = '1' then
+      v := REG_INIT_C;
+    end if;
+
+    r_in <= v;
+  end process comb;
+
+  seq : process ( clk ) is
+  begin
+    if rising_edge(clk) then
+      r <= r_in;
+    end if;
+  end process seq;
+
+end behav;

--- a/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr_sim.vhd
+++ b/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr_sim.vhd
@@ -1,0 +1,163 @@
+-----------------------------------------------------------------------------
+-- Title      : 
+-------------------------------------------------------------------------------
+-- File       : hsd_fex_corr_sim.vhd
+-- Author     : Matt Weaver <weaver@slac.stanford.edu>
+-- Company    : SLAC National Accelerator Laboratory
+-- Created    : 2015-07-10
+-- Last update: 2024-10-01
+-- Platform   : 
+-- Standard   : VHDL'93/02
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- This file is part of 'LCLS2 DAQ Software'.
+-- It is subject to the license terms in the LICENSE.txt file found in the 
+-- top-level directory of this distribution and at: 
+--    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html. 
+-- No part of 'LCLS2 DAQ Software', including this file, 
+-- may be copied, modified, propagated, or distributed except according to 
+-- the terms contained in the LICENSE.txt file.
+-------------------------------------------------------------------------------
+
+library ieee;
+use ieee.std_logic_1164.all;
+use IEEE.NUMERIC_STD.all;
+use ieee.std_logic_unsigned.all;
+
+use STD.textio.all;
+use ieee.std_logic_textio.all;
+
+library surf;
+use surf.StdRtlPkg.all;
+
+library work;
+use work.FmcPkg.all;
+
+entity hsd_fex_corr_sim is
+end hsd_fex_corr_sim;
+
+architecture top_level_app of hsd_fex_corr_sim is
+
+  --  Number of ADC data samples passed on one clk cycle
+  constant NUMWORDS_C : integer := 40;
+  constant NUMACCUM_C : integer := 12;
+  constant BASELINE_C : slv(14 downto 0) := toSlv(2**14,15);
+  
+  signal clk64g : sl;
+  signal rst, rst160, clk160 : sl;
+  signal startBase : sl;
+  signal adcIn  : AdcWordArray(NUMWORDS_C-1 downto 0);
+  signal adcOut, adcOut2 : Slv15Array  (NUMWORDS_C-1 downto 0);
+  signal adcSerialIn  : AdcWord;
+  signal adcSerialOut : slv(15 downto 0);
+  signal tIn  : Slv2Array(NUMWORDS_C/4-1 downto 0) := (others=>"00");
+  signal tOut : Slv2Array(NUMWORDS_C/4-1 downto 0);
+
+begin
+
+  -- generate a 6.4 GHz clock
+  clk_p : process is
+  begin
+    clk64g <= '0';
+    wait for 0.1 ns;
+    clk64g <= '1';
+    wait for 0.1 ns;
+  end process clk_p;
+  
+  -- generate the 160 MHz clk used by the FPGA logic
+  clk160_p : process is
+  begin
+    clk160 <= '0';
+    for i in 0 to 19 loop
+      wait until rising_edge(clk64g);
+    end loop;
+    clk160 <= '1';
+    for i in 0 to 19 loop
+      wait until rising_edge(clk64g);
+    end loop;
+  end process clk160_p;
+
+  -- generate a reset at startup
+  rst_p : process is
+  begin
+    rst <= '1';
+    wait for 50 ns;
+    rst <= '0';
+    wait;
+  end process rst_p;
+
+  U_RST160 : entity surf.RstSync
+    port map ( clk      => clk160,
+               asyncRst => rst,
+               syncRst  => rst160 );
+      
+  -- read the raw data from a file
+  U_ADC_In : entity work.AdcDataFromFile
+    generic map ( FILENAME_G => "adcin.dat",
+                  NUMWORDS_G => NUMWORDS_C )
+    port map ( rst      => rst160,
+               clk      => clk160,
+               adcWords => adcIn,
+               start    => startBase );
+
+  -- correct the data
+  U_CORR_SIM : entity work.hsd_fex_corr
+    generic map ( NUMWORDS_G => NUMWORDS_C,
+                  NUMACCUM_G => NUMACCUM_C,
+                  BASELINE_G => BASELINE_C )
+    port map ( rst       => rst160,
+               clk       => clk160,
+               start     => startBase,
+               adcIn     => adcIn,
+               adcOut    => adcOut );
+
+  GEN_HWCORR : if false generate
+    tIn(0)(0) <= startBase;
+    
+    U_CORR : entity work.hsd_baseline_corr
+      port map ( rst       => rst160,
+                 clk       => clk160,
+                 accShift  => toSlv(NUMACCUM_C,4),
+                 baseline  => BASELINE_C,
+                 tIn       => tIn,
+                 adcIn     => adcIn,
+                 tOut      => tOut,
+                 adcOut    => adcOut2 );
+  end generate;
+  
+  -- write the corrected data to a file
+  U_ADC_Out : entity work.AdcDataToFile
+    generic map ( FILENAME_G => "adcout.dat",
+                  NUMWORDS_G => NUMWORDS_C )
+    port map ( rst      => rst160,
+               clk      => clk160,
+               adcWords => adcOut,
+               start    => startBase );
+
+  --  this is just for display
+  adc64g_p : process (clk64g) is
+    variable adcDataIn  : AdcWordArray(NUMWORDS_C-1 downto 0) := (others=>x"000");
+    variable adcDataOut : Slv15Array(NUMWORDS_C-1 downto 0) := (others=>toSlv(0,15));
+    variable index : integer := 39;
+  begin
+    if rising_edge(clk64g) then
+      if rst160 = '1' then
+        adcSerialIn  <= x"000";
+        adcSerialOut <= x"0000";
+        index        := NUMWORDS_C-1;
+        adcDataIn    := (others=>x"000");
+        adcDataOut   := (others=>toSlv(0,15));
+      else
+        if index = NUMWORDS_C-1 then
+          index      := 0;
+          adcDataIn  := adcIn;
+          adcDataOut := adcOut;
+        end if;
+        adcSerialIn  <= adcDataIn (index);
+        adcSerialOut <= resize(adcDataOut(index),16);
+        index := index + 1;
+      end if;
+    end if;
+  end process adc64g_p;
+  
+end top_level_app;

--- a/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr_sim.vhd
+++ b/firmware/targets/hsd_fex_corr_sim/hdl/hsd_fex_corr_sim.vhd
@@ -5,7 +5,7 @@
 -- Author     : Matt Weaver <weaver@slac.stanford.edu>
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2015-07-10
--- Last update: 2024-10-01
+-- Last update: 2024-10-10
 -- Platform   : 
 -- Standard   : VHDL'93/02
 -------------------------------------------------------------------------------
@@ -40,7 +40,8 @@ architecture top_level_app of hsd_fex_corr_sim is
 
   --  Number of ADC data samples passed on one clk cycle
   constant NUMWORDS_C : integer := 40;
-  constant NUMACCUM_C : integer := 12;
+  --constant NUMACCUM_C : integer := 12;
+  constant NUMACCUM_C : integer := 6;
   constant BASELINE_C : slv(14 downto 0) := toSlv(2**14,15);
   
   signal clk64g : sl;
@@ -111,7 +112,7 @@ begin
                adcIn     => adcIn,
                adcOut    => adcOut );
 
-  GEN_HWCORR : if false generate
+  GEN_HWCORR : if true generate
     tIn(0)(0) <= startBase;
     
     U_CORR : entity work.hsd_baseline_corr

--- a/firmware/targets/hsd_fex_corr_sim/ruckus.tcl
+++ b/firmware/targets/hsd_fex_corr_sim/ruckus.tcl
@@ -1,0 +1,16 @@
+############################
+# DO NOT EDIT THE CODE BELOW
+############################
+
+# Load RUCKUS environment and library
+source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
+
+# Load submodules' code and constraints
+loadRuckusTcl "$::DIR_PATH/../../submodules"
+#loadRuckusTcl "$::DIR_PATH/../../common"
+loadRuckusTcl "$::DIR_PATH/../../common/fex"
+loadRuckusTcl "$::DIR_PATH/../../common/sim"
+loadSource -path "$::DIR_PATH/../../common/PC821/Fmc134/rtl/FmcPkg/FmcPkg.vhd"
+
+# Load target's source code and constraints
+loadSource      -dir  "$::DIR_PATH/hdl/"

--- a/firmware/targets/shared_config.mk
+++ b/firmware/targets/shared_config.mk
@@ -1,2 +1,2 @@
 # Define Firmware Version:
-export PRJ_VERSION = 0x06000000
+export PRJ_VERSION = 0x06010000

--- a/software/scripts/hsdCorrGen.py
+++ b/software/scripts/hsdCorrGen.py
@@ -1,0 +1,71 @@
+#
+#  Generate input data for baseline correction simulation and output for validation
+#
+#  Separate biased baseline and smooth signal
+#  Assert only baseline during correction accumulation
+
+import random
+import numpy
+
+# naccums = 12 => 2**9 (512) rows
+nsamples = 3200   # 80 rows of 40
+
+baseline = [0x7ff,0x800,0x801,0x802]
+signal   = [-0x008,0x010,0x010,-0x008]
+
+baserow = []
+for i in range(10):
+    baserow.extend(baseline)
+
+signrow = signal+[0]*36
+qrow = numpy.array(baserow) + numpy.array(signrow)
+
+print(f'baserow {baserow}')
+print(f'signrow {signrow}')
+print(f'qrow    {qrow}')
+
+x = []
+t = []
+for i in range(540):
+    x.extend(baserow)
+    t.append(0)
+
+for i in range(4):
+    x.extend(qrow.tolist())
+t.extend([1,0,0,0])
+
+for i in range(3):
+    x.extend(baserow)
+    t.append(0)
+
+for i in range(6):
+    x.extend(qrow.tolist())
+    t.append(0)
+
+for i in range(6):
+    x.extend(baserow)
+    t.append(0)
+
+for i in range(1):
+    x.extend(qrow.tolist())
+    t.append(0)
+    
+x = numpy.array(x)
+         
+row = 0
+f = open('adcin','w')
+
+def writeline(x,t):
+    global row
+    y = x[40*row:40*(row+1)]
+    s = ' '
+    s += numpy.array2string(y,max_line_width=1024, formatter={'int':lambda z: '%03x'%z})[1:-1]
+    s += f' {t[row]}\n'
+    f.write(s)
+    row += 1
+    if row*40 >= len(x):
+        row = 0
+
+for i in range(1000):
+    writeline(x,t)
+         


### PR DESCRIPTION
Add a module which continuously computes a baseline correction and applies it at the opening of each triggered gate.  The correction is configurable both for the number of samples it averages and the new baseline value.  The output data is transformed from 12-bit to 15-bit with 4 fractional bits (F11:4); thus, one bit of dynamic range is discarded.  Because most signals are unipolar, the range can be recorded by setting the new baseline value to the appropriate end of 0..2**15.